### PR TITLE
Data component take 1

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "dependencies": {
     "apollo-client-preset": "^1.0.6",
+    "apollo-link": "^1.0.7",
+    "apollo-link-state": "^0.3.1",
     "casual-browserify": "^1.5.12",
     "graphql": "^0.12.3",
     "graphql-tag": "^2.6.1",

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -1,21 +1,14 @@
 import React from 'react'
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom'
-import Home from './components/Home'
-import Data from './components/Data'
-import Test2 from './components/Test2'
-import Navigation from './components/Navigation'
+import DataPage from './components/DataPage'
 
 import './App.css'
 
 const App = () => (
   <Router>
     <div>
-      <Navigation />
       <Switch>
-        <Route exact path="/" component={Home} />
-        <Route path="/data" component={Data} />
-        <Route path="/test2" component={Test2} />
-        <Route render={() => <h2>Page not found</h2>} />
+        <Route exact path="/" component={DataPage} />
       </Switch>
     </div>
   </Router>

--- a/ui/src/components/Data.js
+++ b/ui/src/components/Data.js
@@ -1,52 +1,44 @@
 import React from 'react'
-import { graphql, compose } from 'react-apollo'
+import { graphql } from 'react-apollo'
 import gql from 'graphql-tag'
 
 const Data = props => {
-  console.log(props)
-  //add some loading stuff here because otherwise no bueno
-  //going to try and see if I can grab UID & PCODE from local state
+  const { evaluationData: { evaluationsFor } } = props
+
+  if (!evaluationsFor) {
+    return null
+  }
+
   return (
     <div>
       <h2>Data</h2>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <h3>Year Built</h3>
+            </td>
+            <td>
+              <h3>Energuide rating</h3>
+            </td>
+          </tr>
+          <tr>
+            <td>{evaluationsFor.yearBuilt}</td>
+            <td>{evaluationsFor.eghrating}</td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   )
 }
 
 const EvaluationQuery = gql`
-  query EvaluationQuery($UID: Int!) {
-    evaluationsFor(account: $UID, postalCode: "M8H 1N1") {
+  query EvaluationQuery($clientUID: Int!, $clientPCODE: PostalCode!) {
+    evaluationsFor(account: $clientUID, postalCode: $clientPCODE) {
       yearBuilt
+      eghrating
     }
   }
 `
 
-const clientDataQuery = gql`
-  query clientDataQuery {
-    clientData @client {
-      UID
-      PCODE
-    }
-  }
-`
-
-//export default compose(graphql(EvaluationQuery), graphql(clientDataQuery))(Data)
-//export default graphql(clientDataQuery)(Data)
-
-//export default graphql(EvaluationQuery, { name: 'EvaluationQuery' })(Data)
-export default graphql(EvaluationQuery, {
-  options: ({ UID }) => ({ variables: { UID } }),
-})(Data)
-
-/*const EvaluationQuery = gql`
-  query EvaluationQuery($UID: Int!, $PCODE: PostalCode!) {
-    evaluationsFor(account: $UID, postalCode: $PCODE) {
-      yearBuilt
-    }
-  }
-`
-export default graphql(EvaluationQuery, {
-  options: { variables: { UID: 761266, PCODE: 'M8H 1N1' } },
-})(Data)*/
-
-//export default graphql(EvaluationQuery, { name: 'EvaluationQuery' })(Data)
+export default graphql(EvaluationQuery, { name: 'evaluationData' })(Data)

--- a/ui/src/components/Data.js
+++ b/ui/src/components/Data.js
@@ -1,12 +1,52 @@
 import React from 'react'
-import { withApollo } from 'react-apollo'
+import { graphql, compose } from 'react-apollo'
+import gql from 'graphql-tag'
 
 const Data = props => {
+  console.log(props)
+  //add some loading stuff here because otherwise no bueno
+  //going to try and see if I can grab UID & PCODE from local state
   return (
     <div>
-      <h2>Test</h2>
+      <h2>Data</h2>
     </div>
   )
 }
 
-export default withApollo(Data)
+const EvaluationQuery = gql`
+  query EvaluationQuery($UID: Int!) {
+    evaluationsFor(account: $UID, postalCode: "M8H 1N1") {
+      yearBuilt
+    }
+  }
+`
+
+const clientDataQuery = gql`
+  query clientDataQuery {
+    clientData @client {
+      UID
+      PCODE
+    }
+  }
+`
+
+//export default compose(graphql(EvaluationQuery), graphql(clientDataQuery))(Data)
+//export default graphql(clientDataQuery)(Data)
+
+//export default graphql(EvaluationQuery, { name: 'EvaluationQuery' })(Data)
+export default graphql(EvaluationQuery, {
+  options: ({ UID }) => ({ variables: { UID } }),
+})(Data)
+
+/*const EvaluationQuery = gql`
+  query EvaluationQuery($UID: Int!, $PCODE: PostalCode!) {
+    evaluationsFor(account: $UID, postalCode: $PCODE) {
+      yearBuilt
+    }
+  }
+`
+export default graphql(EvaluationQuery, {
+  options: { variables: { UID: 761266, PCODE: 'M8H 1N1' } },
+})(Data)*/
+
+//export default graphql(EvaluationQuery, { name: 'EvaluationQuery' })(Data)

--- a/ui/src/components/DataPage.js
+++ b/ui/src/components/DataPage.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
+import Data from './Data'
+
+const DataPage = ({ data: { clientData } }) => {
+  return (
+    <div>
+      {/*}<Data clientUID={clientData.UID} clientPCODE={clientData.PCODE} />*/}
+      <Data UID={clientData.UID} />
+    </div>
+  )
+}
+
+const clientDataQuery = gql`
+  query clientDataQuery {
+    clientData @client {
+      UID
+      PCODE
+    }
+  }
+`
+export default graphql(clientDataQuery)(DataPage)

--- a/ui/src/components/DataPage.js
+++ b/ui/src/components/DataPage.js
@@ -6,8 +6,7 @@ import Data from './Data'
 const DataPage = ({ data: { clientData } }) => {
   return (
     <div>
-      {/*}<Data clientUID={clientData.UID} clientPCODE={clientData.PCODE} />*/}
-      <Data UID={clientData.UID} />
+      <Data clientUID={clientData.UID} clientPCODE={clientData.PCODE} />
     </div>
   )
 }

--- a/ui/src/components/Home.js
+++ b/ui/src/components/Home.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import Form from './Form'
 import gql from 'graphql-tag'
-import { withApollo } from 'react-apollo'
 
 class Home extends React.Component {
   constructor() {
@@ -11,7 +10,6 @@ class Home extends React.Component {
     this.handleFormChange = this.handleFormChange.bind(this)
 
     this.state = {
-      data: false,
       UID: null,
       PCODE: null,
     }
@@ -30,56 +28,22 @@ class Home extends React.Component {
   async handleFormSubmit(event) {
     event.preventDefault()
 
-    let { client } = this.props
-
-    let response = await client.query({
-      query: gql`
-        query evaluationQuery($UID: Int!, $PCODE: String!) {
-          evaluationsFor(account: $UID, postalCode: $PCODE) {
-            yearBuilt
-          }
-        }
-      `,
-      variables: {
-        UID: this.state.UID,
-        PCODE: this.state.PCODE,
-      },
-    })
-
-    this.setState({ data: response.data.evaluationsFor })
+    //fire mutation to store UID & PCODE in local state
   }
 
   handleResetClick() {
+    //this is probably getting removed?
     this.setState({
-      data: false,
       UID: null,
       PCODE: null,
     })
   }
 
   render() {
-    if (!this.state.data)
-      return (
-        <Form
-          onSubmit={this.handleFormSubmit}
-          onChange={this.handleFormChange}
-        />
-      )
-    else
-      return (
-        <div>
-          <br />
-          <br />
-          <div>
-            <strong>year built:</strong>
-          </div>
-          <div className="yearBuilt">{this.state.data.yearBuilt}</div>
-          <br />
-          <br />
-          <button onClick={this.handleResetClick}>Reset data</button>
-        </div>
-      )
+    return (
+      <Form onSubmit={this.handleFormSubmit} onChange={this.handleFormChange} />
+    )
   }
 }
 
-export default withApollo(Home)
+export default Home

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -4,13 +4,25 @@ import './index.css'
 import App from './App'
 import registerServiceWorker from './registerServiceWorker'
 import { ApolloClient } from 'apollo-client'
+import { ApolloLink } from 'apollo-link'
 import { HttpLink } from 'apollo-link-http'
+import { withClientState } from 'apollo-link-state'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 import { ApolloProvider } from 'react-apollo'
 
+import { defaults, resolvers } from './resolvers'
+
+const cache = new InMemoryCache()
+
+const stateLink = withClientState({ resolvers, cache, defaults })
+
 const client = new ApolloClient({
-  link: new HttpLink({ uri: 'http://localhost:3001/graphql' }),
-  cache: new InMemoryCache(),
+  link: ApolloLink.from([
+    stateLink,
+    //new HttpLink({ uri: 'http://localhost:3001/graphql' }),
+    new HttpLink({ uri: 'http://energuide.cds-snc.ca/graphql' }),
+  ]),
+  cache,
 })
 
 ReactDOM.render(

--- a/ui/src/resolvers/index.js
+++ b/ui/src/resolvers/index.js
@@ -1,0 +1,15 @@
+export const defaults = {
+  clientData: {
+    __typename: 'clientData',
+    UID: 761266,
+    PCODE: 'M8H 1N1',
+  },
+}
+
+export const resolvers = {
+  Mutation: {
+    setClientData: (_, { uid, pcode }, { cache }) => {
+      cache.writeData({ clientData: { UID: uid, PCODE: pcode } })
+    },
+  },
+}

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -192,6 +192,13 @@ apollo-link-http@^1.3.1:
   dependencies:
     apollo-link "^1.0.7"
 
+apollo-link-state@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/apollo-link-state/-/apollo-link-state-0.3.1.tgz#e323d41357bb908c7b888d51a5650b8cdcef025d"
+  dependencies:
+    apollo-utilities "^1.0.1"
+    graphql-anywhere "^4.1.0-alpha.0"
+
 apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.0.7.tgz#42cd38a7378332fc3e41a214ff6a6e5e703a556f"
@@ -203,6 +210,10 @@ apollo-link@^1.0.0, apollo-link@^1.0.6, apollo-link@^1.0.7:
 apollo-utilities@^1.0.0, apollo-utilities@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.4.tgz#560009ea5541b9fdc4ee07ebb1714ee319a76c15"
+
+apollo-utilities@^1.0.1, apollo-utilities@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/apollo-utilities/-/apollo-utilities-1.0.5.tgz#a5e99507d730ce21e84e07c7a9c7586b2ccdc58e"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -2957,6 +2968,12 @@ got@^5.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+graphql-anywhere@^4.1.0-alpha.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/graphql-anywhere/-/graphql-anywhere-4.1.2.tgz#55e58593158f3deb0814def522c55e948c57cabb"
+  dependencies:
+    apollo-utilities "^1.0.5"
 
 graphql-anywhere@^4.1.1:
   version "4.1.1"


### PR DESCRIPTION
This is a "opinion on approach request" PR.

Goal: Create a basic data component that renders some data from the API.

Approach:
- Point client to proper API so no need to fire up the test api (to be cleaned up later)
- set up apollo-link-state with working default UID & Postal Code values in cache
- created a DataPage component wrapped in a query to the client for stored UID & Postal Code values
- DataPage renders a Data component that accepts UID & Postal Code as props 
- Data component is wrapped in a query to the API that provides year built & energuide values as props to the component for rendering

Envisioned next steps (If this is a sane approach): 
- add a mutation to the form that writes the UID & Postal Code to cache on submit, then redirect to data page. Solves the pesky faux routing going on currently
- Look into [recompose](https://www.apollographql.com/docs/react/recipes/recompose.html) for better loading state handling 
