### PR TITLE
Basic home component tests

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "apollo-link": "^1.0.7",
     "apollo-link-state": "^0.3.1",
     "casual-browserify": "^1.5.12",
+    "enzyme-adapter-react-16": "^1.1.1",
     "graphql": "^0.12.3",
     "graphql-tag": "^2.6.1",
     "react": "^16.2.0",
@@ -14,7 +15,8 @@
     "react-dom": "^16.2.0",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
-    "react-scripts": "1.0.17"
+    "react-scripts": "1.0.17",
+    "react-test-renderer": "^16.2.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/ui/src/components/Form.js
+++ b/ui/src/components/Form.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types'
 
 const Form = props => {
   Form.propTypes = {
-    onSubmit: PropTypes.func,
-    onChange: PropTypes.func,
-    uidValue: PropTypes.string,
-    pcodeValue: PropTypes.string,
+    onSubmit: PropTypes.func.isRequired,
+    onChange: PropTypes.func.isRequired,
+    uidValue: PropTypes.string.isRequired,
+    pcodeValue: PropTypes.string.isRequired,
   }
 
   return (

--- a/ui/src/components/Home.js
+++ b/ui/src/components/Home.js
@@ -4,13 +4,12 @@ import gql from 'graphql-tag'
 import { graphql, compose } from 'react-apollo'
 import PropTypes from 'prop-types'
 
-class Home extends React.Component {
+export class Home extends React.Component {
   constructor(props) {
-    super(props)
+    super()
 
     this.handleFormSubmit = this.handleFormSubmit.bind(this)
     this.handleFormChange = this.handleFormChange.bind(this)
-    console.log(props)
   }
 
   handleFormChange(event) {
@@ -33,12 +32,15 @@ class Home extends React.Component {
 
   render() {
     return (
-      <Form
-        onSubmit={this.handleFormSubmit}
-        onChange={this.handleFormChange}
-        uidValue={this.props.UID}
-        pcodeValue={this.props.PCODE}
-      />
+      <div>
+        <h2>Title of page</h2>
+        <Form
+          onSubmit={this.handleFormSubmit}
+          onChange={this.handleFormChange}
+          uidValue={this.props.UID}
+          pcodeValue={this.props.PCODE}
+        />
+      </div>
     )
   }
 }

--- a/ui/src/components/Home.test.js
+++ b/ui/src/components/Home.test.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import { shallow, mount } from 'enzyme'
+import { Home } from './Home'
+
+//boilerplate
+describe('Home Component', () => {
+  //Div is always rendered
+  it('Should always render a div', () => {
+    const wrapper = shallow(<Home />)
+    expect(wrapper.find('div').length).toBeGreaterThan(0)
+  })
+  //Div contains everything else that is rendered
+  it('Should be contained within a div', () => {})
+  //A form is always rendered
+  //Form accepts 4 props
+  //Form UID value is equal to prop uidValue
+  //Form PCODE value is equal to prop pcodeValue
+  //Clicking the submit button calls onSubmit function
+  //Typing input calls the onChange function
+})

--- a/ui/src/components/Home.test.js
+++ b/ui/src/components/Home.test.js
@@ -1,20 +1,31 @@
 import React from 'react'
 import { shallow, mount } from 'enzyme'
 import { Home } from './Home'
+import Form from './Form'
 
-//boilerplate
 describe('Home Component', () => {
-  //Div is always rendered
+  let HomeComponent = shallow(<Home />)
   it('Should always render a div', () => {
-    const wrapper = shallow(<Home />)
-    expect(wrapper.find('div').length).toBeGreaterThan(0)
+    expect(HomeComponent.find('div').length).toBeGreaterThan(0)
   })
-  //Div contains everything else that is rendered
-  it('Should be contained within a div', () => {})
-  //A form is always rendered
+  describe('The rendered div', () => {
+    it('Should contain everything else that gets rendered', () => {
+      const divs = HomeComponent.find('div')
+      const wrappingDiv = divs.first()
+
+      expect(wrappingDiv.children()).toEqual(HomeComponent.children())
+    })
+  })
+  it('Should always render a form', () => {
+    expect(HomeComponent.find('Form').length).toEqual(1)
+  })
+  describe('Rendered form', () => {
+    it('Should accept four props', () => {
+      const form = HomeComponent.find(Form)
+      expect(Object.keys(form.props()).length).toBe(4)
+    })
+  })
   //Form accepts 4 props
-  //Form UID value is equal to prop uidValue
-  //Form PCODE value is equal to prop pcodeValue
   //Clicking the submit button calls onSubmit function
-  //Typing input calls the onChange function
+  //Typing input calls the correct onChange function
 })

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,0 +1,4 @@
+import { configure } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+configure({ adapter: new Adapter() })

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2149,6 +2149,26 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
+enzyme-adapter-react-16@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+  dependencies:
+    enzyme-adapter-utils "^1.3.0"
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    object.values "^1.0.4"
+    prop-types "^15.6.0"
+    react-reconciler "^0.7.0"
+    react-test-renderer "^16.0.0-0"
+
+enzyme-adapter-utils@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz#d6c85756826c257a8544d362cc7a67e97ea698c7"
+  dependencies:
+    lodash "^4.17.4"
+    object.assign "^4.0.4"
+    prop-types "^15.6.0"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"
@@ -4619,7 +4639,7 @@ object-keys@^1.0.11, object-keys@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
-object.assign@^4.1.0:
+object.assign@^4.0.4, object.assign@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
   dependencies:
@@ -5466,6 +5486,15 @@ react-error-overlay@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-3.0.0.tgz#c2bc8f4d91f1375b3dad6d75265d51cd5eeaf655"
 
+react-reconciler@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/react-reconciler/-/react-reconciler-0.7.0.tgz#9614894103e5f138deeeb5eabaf3ee80eb1d026d"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
+
 react-router-dom@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-4.2.2.tgz#c8a81df3adc58bba8a76782e946cbd4eae649b8d"
@@ -5531,6 +5560,14 @@ react-scripts@1.0.17:
     whatwg-fetch "2.0.3"
   optionalDependencies:
     fsevents "1.1.2"
+
+react-test-renderer@^16.0.0-0, react-test-renderer@^16.2.0:
+  version "16.2.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.2.0.tgz#bddf259a6b8fcd8555f012afc8eacc238872a211"
+  dependencies:
+    fbjs "^0.8.16"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 react@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
Goal: Create tests to assert basic behaviour of the Home component (render div, render form, form should accept 4 props, rendered children should be wrapped in div)

- Added ability to export Home component w/o wrapped Apollo Client props. I don't think it should be necessary for unit testing?
- Added propTypes to Form & Home component to catch any issues with props

To do: create tests to assert behaviour of form onChange & onSubmit events. I feel like that should be a good first stab at the functionality of the current Home component. 